### PR TITLE
CHK-12 updating the way files missing at S3 are handled

### DIFF
--- a/checkfiles.py
+++ b/checkfiles.py
@@ -1087,8 +1087,10 @@ def run(out, err, url, username, password, encValData, mirror, search_query, fil
 
             if not job.get('skip'):
                 errors_string = str(job.get('errors', {'errors': None}))
-            else:
-                errors_string = str({'errors': 'status have not been changed, the file check was skipped due to the file unavailability on S3'})
+            elif not errors['file_not_found']:
+                errors_string = str({'errors':
+                                     'status have not been changed, the file '
+                                     'check was skipped due to the file unavailability on S3'})
             tab_report = '\t'.join([
                 job['item'].get('accession', 'UNKNOWN'),
                 job['item'].get('lab', 'UNKNOWN'),

--- a/checkfiles.py
+++ b/checkfiles.py
@@ -1085,16 +1085,15 @@ def run(out, err, url, username, password, encValData, mirror, search_query, fil
             if not dry_run:
                 patch_file(session, url, job)
 
-            if not job.get('skip'):
-                errors_string = str(job.get('errors', {'errors': None}))
-            elif not errors['file_not_found']:
+            errors_string = job.get('errors', {'errors': None})
+            if job.get('skip') and errors_string and not job['errors'].get('file_not_found'):
                 errors_string = str({'errors':
                                      'status have not been changed, the file '
                                      'check was skipped due to the file unavailability on S3'})
             tab_report = '\t'.join([
                 job['item'].get('accession', 'UNKNOWN'),
                 job['item'].get('lab', 'UNKNOWN'),
-                errors_string,
+                str(errors_string),
                 str(job['item'].get('aliases', ['n/a'])),
                 job.get('upload_url', ''),
                 job.get('upload_expiration', ''),

--- a/checkfiles.py
+++ b/checkfiles.py
@@ -1081,7 +1081,7 @@ def run(out, err, url, username, password, encValData, mirror, search_query, fil
         jobs = fetch_files(session, url, search_query, out, include_unexpired_upload, file_list, local_file)
         if not json_out:
             headers = '\t'.join(['Accession', 'Lab', 'Errors', 'Aliases', 'Upload URL',
-                                'Upload Expiration'])
+                                 'Upload Expiration'])
             out.write(headers + '\n')
             out.flush()
         for job in imap(functools.partial(check_file, config, session, url), jobs):
@@ -1093,7 +1093,7 @@ def run(out, err, url, username, password, encValData, mirror, search_query, fil
                 errors_string = jobs_errors
             elif job.get('skip'):
                 errors_string = str({'errors':
-                                     'status have not been changed, the file '
+                                     'File status have not been changed, the file\' '
                                      'check was skipped due to the file unavailability on S3'})
             tab_report = '\t'.join([
                 job['item'].get('accession', 'UNKNOWN'),

--- a/checkfiles.py
+++ b/checkfiles.py
@@ -1086,7 +1086,7 @@ def run(out, err, url, username, password, encValData, mirror, search_query, fil
                 patch_file(session, url, job)
 
             errors_string = job.get('errors', {'errors': None})
-            if job.get('skip') and (not error_string or not job['errors'].get('file_not_found')):
+            if job.get('skip') and not error_string.get('errors'):
                 errors_string = str({'errors':
                                      'status have not been changed, the file '
                                      'check was skipped due to the file unavailability on S3'})

--- a/checkfiles.py
+++ b/checkfiles.py
@@ -1086,7 +1086,7 @@ def run(out, err, url, username, password, encValData, mirror, search_query, fil
                 patch_file(session, url, job)
 
             errors_string = job.get('errors', {'errors': None})
-            if job.get('skip') and errors_string and not job['errors'].get('file_not_found'):
+            if job.get('skip') and (not error_string or not job['errors'].get('file_not_found')):
                 errors_string = str({'errors':
                                      'status have not been changed, the file '
                                      'check was skipped due to the file unavailability on S3'})

--- a/checkfiles.py
+++ b/checkfiles.py
@@ -1018,7 +1018,7 @@ def run(out, err, url, username, password, encValData, mirror, search_query, fil
     except multiprocessing.NotImplmentedError:
         nprocesses = 1
 
-    version = '1.19'
+    version = '1.20'
 
     try:
         ip_output = subprocess.check_output(


### PR DESCRIPTION
In case file credentials have not expired the status will not change into "upload failed" even if th efile is not in S3. If credentials are expired - the file status will go into "upload failed".