### PR TITLE
CHK-63-add-biginteract-validation

### DIFF
--- a/checkfiles.py
+++ b/checkfiles.py
@@ -120,6 +120,7 @@ def check_format(encValData, job, path):
         ('fastq', None): ['-type=fastq'],
         ('bam', None): ['-type=bam', chromInfo],
         ('bigWig', None): ['-type=bigWig', chromInfo],
+        ('bigInteract', None): ['-type=bigBed5+13', chromInfo, '-as=%s/as/interact.as' % encValData],
         # standard bed formats
         ('bed', 'bed3'): ['-type=bed3', chromInfo],
         ('bigBed', 'bed3'): ['-type=bigBed3', chromInfo],


### PR DESCRIPTION
Please see WRAN-1740 for comments about why the type is bigBed and not bigInteract